### PR TITLE
Add servername option to SecureProxy config to pass SNI validation

### DIFF
--- a/lib/proxies/SecureProxy.js
+++ b/lib/proxies/SecureProxy.js
@@ -10,7 +10,8 @@ class SecureProxy extends Proxy {
       ca: null,
       cert: null,
       key: null,
-      checkServerIdentity: false
+      checkServerIdentity: false,
+      servername: null
     }, config)
     super(destination, name, type, config)
     this.secure = true
@@ -25,6 +26,7 @@ class SecureProxy extends Proxy {
     if (this.config.ca) params.ca = this.config.ca
     if (this.config.cert) params.cert = this.config.cert
     if (this.config.key) params.key = this.config.key
+    if (this.config.servername) params.servername = this.config.servername
     if (this.config.checkServerIdentity) params.checkServerIdentity = this.config.checkServerIdentity
     if (this.config.checkServerIdentity === false) {
       params.checkServerIdentity = function () {}


### PR DESCRIPTION
I encountered the following error when using SecureProxy in LocalServer:
```
Error: Client network socket disconnected before secure TLS connection was established
    at connResetException (internal/errors.js:607:14)
    at TLSSocket.onConnectEnd (_tls_wrap.js:1544:19)
    at TLSSocket.emit (events.js:327:22)
    at endReadableNT (internal/streams/readable.js:1327:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```

The solution to this is adding the `servername` configuration property, which has something to do with SNI validation. Here's how to reproduce the error:

```
const tls = require('tls');
const done = (err, val) => {
  console.log(err, val);
};
const socket = tls.connect({
  host: 'demo.noop.app',
  port: 443,
  ALPNProtocols: ['h2', 'http/1.1'],
});
socket.once('error', done);
socket.on('secureConnect', () => {
  socket.destroy();
  done();
});
```